### PR TITLE
Change plugin stage statement parsing from Meta to ExprCall

### DIFF
--- a/bevy-butler-proc-macro/src/butler_plugin/structs/plugin_stage_data.rs
+++ b/bevy-butler-proc-macro/src/butler_plugin/structs/plugin_stage_data.rs
@@ -1,6 +1,6 @@
 use proc_macro2::Span;
-use quote::{format_ident, quote};
-use syn::{parse::{Parse, ParseStream, Parser}, punctuated::Punctuated, spanned::Spanned, Error, Expr, ExprBlock, ExprCall, Ident, ImplItemFn, Meta, MetaList, MetaNameValue, Token};
+use quote::format_ident;
+use syn::{parse::{Parse, ParseStream, Parser}, punctuated::Punctuated, spanned::Spanned, Error, Expr, ExprBlock, ExprCall, Ident, ImplItemFn, Meta, Token};
 
 use super::PluginStage;
 
@@ -11,11 +11,7 @@ pub(crate) struct PluginStageData {
 }
 
 fn parse_stage_stmt(input: ParseStream) -> syn::Result<ExprCall> {
-    match input.parse::<Meta>()? {
-        Meta::Path(p) => Ok(syn::parse2(quote!(#p ()))?),
-        Meta::NameValue(MetaNameValue { path, value, .. }) => Ok(syn::parse2(quote!(#path (#value)))?),
-        Meta::List(MetaList { path, tokens, ..}) => Ok(syn::parse2(quote!(#path (#tokens)))?),
-    }
+    input.parse::<ExprCall>()
 }
 
 fn parse_stage_stmts(input: ParseStream) -> syn::Result<Punctuated<ExprCall, Token![,]>> {

--- a/tests/butler_plugin/main.rs
+++ b/tests/butler_plugin/main.rs
@@ -4,4 +4,5 @@ pub mod common {
 
 mod butler_plugin;
 mod butler_plugin_impl;
+mod multiple_build_methods;
 mod multiple_plugins;

--- a/tests/butler_plugin/multiple_build_methods.rs
+++ b/tests/butler_plugin/multiple_build_methods.rs
@@ -1,0 +1,25 @@
+use bevy_app::prelude::*;
+use bevy_butler::*;
+use bevy_ecs::prelude::*;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+use super::common::log_plugin;
+
+#[derive(Resource, Default)]
+struct CounterOne(pub u8);
+
+#[derive(Resource, Default)]
+struct CounterTwo(pub u8);
+
+#[butler_plugin(build(init_resource::<CounterOne>(), init_resource::<CounterTwo>()))]
+struct MyPlugin;
+
+#[wasm_bindgen_test(unsupported = test)]
+pub fn butler_plugin_test() {
+    App::new()
+        .add_plugins(log_plugin())
+        .add_plugins(MyPlugin)
+        .add_systems(Startup, |counter: Res<CounterOne>| assert_eq!(counter.0, 0))
+        .add_systems(Startup, |counter: Res<CounterTwo>| assert_eq!(counter.0, 0))
+        .run();
+}

--- a/tests/system/generic_system.rs
+++ b/tests/system/generic_system.rs
@@ -13,9 +13,9 @@ struct GenericResource<T>(pub T, pub bool);
 
 #[butler_plugin {
     build(
-        insert_resource = GenericResource("Hello", false),
-        insert_resource = GenericResource(52u8, false),
-        insert_resource = GenericResource(true, false),
+        insert_resource(GenericResource("Hello", false)),
+        insert_resource(GenericResource(52u8, false)),
+        insert_resource(GenericResource(true, false)),
     )
 }]
 struct MyPlugin;


### PR DESCRIPTION
Fixes #4, although I'm not sure if this is the way it should be fixed considering you can't do
```rs
#[butler_plugin(build(
    insert_resource = MyResource
))]
```
anymore.