### PR TITLE
Added `insert_state` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ bevy_app = { version = "0.16.0", default-features = false }
 bevy_ecs = { version = "0.16.0", default-features = false }
 bevy_log = { version = "0.16.0", default-features = false }
 bevy_state = { version = "0.16.0", default-features = false, features = ["bevy_app"] }
-bevy = { version = "0.16.0", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.16.0", default-features = false, features = ["bevy_log", "bevy_state"] }

--- a/bevy-butler-proc-macro/src/add_event/mod.rs
+++ b/bevy-butler-proc-macro/src/add_event/mod.rs
@@ -2,27 +2,16 @@ use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::*;
-use syn::{Error, Item};
+use syn::Item;
 
-use crate::utils::{butler_plugin_entry_block, get_use_path};
+use crate::utils::{butler_plugin_entry_block, get_struct_or_enum_ident};
 
 pub(crate) mod structs;
 
 pub(crate) fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<TokenStream2> {
     let attr: EventAttr = deluxe::parse(attr)?;
     let item = syn::parse::<Item>(body)?;
-    let event_ident = match &item {
-        Item::Struct(i_struct) => &i_struct.ident,
-        Item::Use(i_use) => get_use_path(&i_use.tree)?,
-        Item::Type(i_type) => &i_type.ident,
-        Item::Enum(i_enum) => &i_enum.ident,
-        item => {
-            return Err(Error::new_spanned(
-                item,
-                "Expected a struct or use statement",
-            ))
-        }
-    };
+    let event_ident = get_struct_or_enum_ident(&item)?;
 
     let plugin = &attr.plugin;
     let generics = &attr.generics;

--- a/bevy-butler-proc-macro/src/add_observer/mod.rs
+++ b/bevy-butler-proc-macro/src/add_observer/mod.rs
@@ -2,9 +2,9 @@ use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::ObserverAttr;
-use syn::{Error, Expr, Ident, Item};
+use syn::{Expr, Ident, Item};
 
-use crate::utils::{butler_plugin_entry_block, get_use_path};
+use crate::utils::{butler_plugin_entry_block, get_fn_ident};
 
 pub(crate) mod structs;
 
@@ -16,11 +16,7 @@ pub(crate) fn parse_observer(attr: &ObserverAttr, ident: &Ident) -> syn::Result<
 pub(crate) fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<TokenStream2> {
     let attr: ObserverAttr = deluxe::parse(attr)?;
     let item = syn::parse::<Item>(body)?;
-    let ident = match &item {
-        Item::Fn(item_fn) => &item_fn.sig.ident,
-        Item::Use(item_use) => get_use_path(&item_use.tree)?,
-        item => return Err(Error::new_spanned(item, "Expected an `fn` or `use` item")),
-    };
+    let ident = get_fn_ident(&item)?;
 
     let plugin = &attr.plugin;
     let obsrv_expr = parse_observer(&attr, ident)?;

--- a/bevy-butler-proc-macro/src/add_plugin/mod.rs
+++ b/bevy-butler-proc-macro/src/add_plugin/mod.rs
@@ -2,37 +2,27 @@ use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::{AddPluginAttr, ButlerTarget};
-use syn::{parse, parse_quote, Error, Fields, Item, ItemEnum, ItemStruct, ItemType, ItemUse};
+use syn::{parse, parse_quote, Fields, Item, ItemStruct};
 
-use crate::utils::{butler_plugin_entry_block, butler_plugin_group_entry_block, get_use_path};
+use crate::utils::{butler_plugin_entry_block, butler_plugin_group_entry_block, get_struct_or_enum_ident};
 
 pub mod structs;
 
 pub(crate) fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<TokenStream2> {
     let mut attr: AddPluginAttr = deluxe::parse(attr)?;
     let item: Item = parse(body)?;
-    let plugin_ident = match &item {
-        Item::Struct(ItemStruct { ident, fields, .. }) => {
-            if attr.init.is_none() && fields.is_empty() {
-                // Unit structs can be initialized using themselves
-                match fields {
-                    Fields::Unit => attr.init = Some(parse_quote!(#ident)),
-                    Fields::Named(_) => attr.init = Some(parse_quote!(#ident {})),
-                    Fields::Unnamed(_) => attr.init = Some(parse_quote!(#ident ())),
-                }
+    let plugin_ident = get_struct_or_enum_ident(&item)?;
+
+    if let Item::Struct(ItemStruct { ident, fields, .. }) = &item {
+        if attr.init.is_none() && fields.is_empty() {
+            // Unit structs can be initialized using themselves
+            match fields {
+                Fields::Unit => attr.init = Some(parse_quote!(#ident)),
+                Fields::Named(_) => attr.init = Some(parse_quote!(#ident {})),
+                Fields::Unnamed(_) => attr.init = Some(parse_quote!(#ident ())),
             }
-            ident
         }
-        Item::Enum(ItemEnum { ident, .. }) => ident,
-        Item::Use(ItemUse { tree, .. }) => get_use_path(tree)?,
-        Item::Type(ItemType { ident, .. }) => ident,
-        item => {
-            return Err(Error::new_spanned(
-                item,
-                "Expected a struct, enum, use statement or type alias",
-            ))
-        }
-    };
+    }
 
     let generics = &attr.generics;
 

--- a/bevy-butler-proc-macro/src/add_plugin_group/mod.rs
+++ b/bevy-butler-proc-macro/src/add_plugin_group/mod.rs
@@ -3,12 +3,12 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::AddPluginGroupAttr;
 use syn::{
-    parse, parse_quote, Error, ExprClosure, Fields, Item, ItemEnum, ItemStruct, ItemType, ItemUse,
+    parse, parse_quote, ExprClosure, Fields, Item, ItemStruct,
 };
 
 use crate::{
     add_plugin::structs::ButlerTarget,
-    utils::{butler_plugin_entry_block, butler_plugin_group_entry_block, get_use_path},
+    utils::{butler_plugin_entry_block, butler_plugin_group_entry_block, get_struct_or_enum_ident},
 };
 
 pub(crate) mod structs;
@@ -17,30 +17,20 @@ pub(crate) fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<
     let mut attr: AddPluginGroupAttr = deluxe::parse(attr)?;
     let item: Item = parse(body)?;
 
-    let plugin_ident = match &item {
-        Item::Struct(ItemStruct { ident, fields, .. }) => {
-            if attr.init.is_none() {
-                if fields.is_empty() {
-                    // Unit structs can be initialized using themselves
-                    match fields {
-                        Fields::Unit => attr.init = Some(parse_quote!(#ident)),
-                        Fields::Named(_) => attr.init = Some(parse_quote!(#ident {})),
-                        Fields::Unnamed(_) => attr.init = Some(parse_quote!(#ident ())),
-                    }
+    let plugin_ident = get_struct_or_enum_ident(&item)?;
+
+    if let Item::Struct(ItemStruct { fields, ident, .. }) = &item {
+        if attr.init.is_none() {
+            if fields.is_empty() {
+                // Unit structs can be initialized using themselves
+                match fields {
+                    Fields::Unit => attr.init = Some(parse_quote!(#ident)),
+                    Fields::Named(_) => attr.init = Some(parse_quote!(#ident {})),
+                    Fields::Unnamed(_) => attr.init = Some(parse_quote!(#ident ())),
                 }
             }
-            ident
         }
-        Item::Enum(ItemEnum { ident, .. }) => ident,
-        Item::Use(ItemUse { tree, .. }) => get_use_path(tree)?,
-        Item::Type(ItemType { ident, .. }) => ident,
-        item => {
-            return Err(Error::new_spanned(
-                item,
-                "Expected a struct, enum, use statement or type alias",
-            ))
-        }
-    };
+    }
 
     if attr.init.is_none() {
         attr.init = Some(parse_quote!(core::default::Default::default()));

--- a/bevy-butler-proc-macro/src/add_system/mod.rs
+++ b/bevy-butler-proc-macro/src/add_system/mod.rs
@@ -3,9 +3,9 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::SystemAttr;
 use syn::Expr;
-use syn::{Error, Ident, Item, ItemFn, ItemUse, Signature};
+use syn::{Ident, Item};
 
-use crate::utils::{butler_plugin_entry_block, get_use_path};
+use crate::utils::{butler_plugin_entry_block, get_fn_ident};
 
 pub mod structs;
 
@@ -36,14 +36,7 @@ pub(crate) fn macro_impl(attr: TokenStream1, item: TokenStream1) -> syn::Result<
     let attr: SystemAttr = deluxe::parse(attr)?;
     let input: Item = syn::parse(item)?;
 
-    let sys_ident = match &input {
-        Item::Fn(ItemFn {
-            sig: Signature { ident, .. },
-            ..
-        }) => ident,
-        Item::Use(ItemUse { tree, .. }) => get_use_path(tree)?,
-        _ => return Err(Error::new_spanned(input, "Expected `fn` or `use`")),
-    };
+    let sys_ident = get_fn_ident(&input)?;
 
     let plugin = &attr.plugin;
     let schedule = &attr.schedule;

--- a/bevy-butler-proc-macro/src/insert_resource/mod.rs
+++ b/bevy-butler-proc-macro/src/insert_resource/mod.rs
@@ -2,27 +2,16 @@ use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use structs::*;
-use syn::{Error, Item};
+use syn::Item;
 
-use crate::utils::{butler_plugin_entry_block, get_use_path};
+use crate::utils::{butler_plugin_entry_block, get_struct_or_enum_ident};
 
 pub(crate) mod structs;
 
 pub(crate) fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<TokenStream2> {
     let attr: ResourceAttr = deluxe::parse(attr)?;
     let item = syn::parse::<Item>(body)?;
-    let res_ident = match &item {
-        Item::Struct(i_struct) => &i_struct.ident,
-        Item::Use(i_use) => get_use_path(&i_use.tree)?,
-        Item::Type(i_type) => &i_type.ident,
-        Item::Enum(i_enum) => &i_enum.ident,
-        item => {
-            return Err(Error::new_spanned(
-                item,
-                "Expected a struct or use statement",
-            ))
-        }
-    };
+    let res_ident = get_struct_or_enum_ident(&item)?;
 
     let plugin = &attr.plugin;
     let generics = &attr.generics;

--- a/bevy-butler-proc-macro/src/insert_state/mod.rs
+++ b/bevy-butler-proc-macro/src/insert_state/mod.rs
@@ -1,0 +1,43 @@
+use proc_macro::TokenStream as TokenStream1;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote, ToTokens};
+use structs::InsertStateAttr;
+use syn::Item;
+
+use crate::utils::{butler_plugin_entry_block, get_struct_or_enum_ident};
+
+pub mod structs;
+
+pub fn macro_impl(attr: TokenStream1, body: TokenStream1) -> syn::Result<TokenStream2> {
+    let attr: InsertStateAttr = deluxe::parse(attr)?;
+    let item: Item = syn::parse(body)?;
+    let ident = get_struct_or_enum_ident(&item)?;
+    let generics = &attr.generics;
+
+    let static_ident = format_ident!(
+        "_butler_state_{}",
+        sha256::digest(&[
+            attr.plugin.to_token_stream().to_string(),
+            attr.generics.to_token_stream().to_string(),
+        ].concat())
+    );
+
+    let register_block = butler_plugin_entry_block(
+        &static_ident,
+        &attr.plugin,
+        &match attr.init {
+            Some(init) => syn::parse_quote! {
+                |app| { ::bevy_butler::__internal::bevy_state::app::AppExtStates::insert_state::<#ident #generics>(app, #init); }
+            },
+            None => syn::parse_quote! {
+                |app| { ::bevy_butler::__internal::bevy_state::app::AppExtStates::init_state::<#ident #generics>(app); }
+            }
+        }
+    );
+
+    Ok(quote! {
+        #item
+
+        #register_block
+    })
+}

--- a/bevy-butler-proc-macro/src/insert_state/structs.rs
+++ b/bevy-butler-proc-macro/src/insert_state/structs.rs
@@ -1,0 +1,9 @@
+use deluxe::ParseMetaItem;
+use syn::{AngleBracketedGenericArguments, Expr, Path};
+
+#[derive(ParseMetaItem)]
+pub struct InsertStateAttr {
+    pub plugin: Path,
+    pub generics: Option<AngleBracketedGenericArguments>,
+    pub init: Option<Expr>,
+}

--- a/bevy-butler-proc-macro/src/lib.rs
+++ b/bevy-butler-proc-macro/src/lib.rs
@@ -64,3 +64,9 @@ pub(crate) mod add_plugin_group;
 pub fn add_plugin_group(attr: TokenStream, body: TokenStream) -> TokenStream {
     result_to_tokens(add_plugin_group::macro_impl(attr, body))
 }
+
+pub(crate) mod insert_state;
+#[proc_macro_attribute]
+pub fn insert_state(attr: TokenStream, body: TokenStream) -> TokenStream {
+    result_to_tokens(insert_state::macro_impl(attr, body))
+}

--- a/bevy-butler-proc-macro/src/utils/mod.rs
+++ b/bevy-butler-proc-macro/src/utils/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{ExprClosure, Ident, Path, UseTree};
+use syn::{Error, ExprClosure, Ident, Item, Path, UseTree};
 
 pub(crate) fn butler_plugin_entry_block(
     static_ident: &Ident,
@@ -36,5 +36,23 @@ pub(crate) fn get_use_path(tree: &UseTree) -> syn::Result<&Ident> {
         UseTree::Group(_) | UseTree::Glob(_) => {
             Err(syn::Error::new_spanned(tree, "Expected a path"))
         }
+    }
+}
+
+pub(crate) fn get_struct_or_enum_ident(item: &Item) -> syn::Result<&Ident> {
+    match item {
+        Item::Struct(i) => Ok(&i.ident),
+        Item::Enum(i) => Ok(&i.ident),
+        Item::Use(i) => get_use_path(&i.tree),
+        Item::Type(i) => Ok(&i.ident),
+        other => Err(Error::new_spanned(other, "Expected a struct, enum, type alias or use statement")),
+    }
+}
+
+pub(crate) fn get_fn_ident(item: &Item) -> syn::Result<&Ident> {
+    match item {
+        Item::Fn(i) => Ok(&i.sig.ident),
+        Item::Use(i) => get_use_path(&i.tree),
+        other => Err(Error::new_spanned(other, "Expected a function or use statement")),
     }
 }

--- a/bevy-butler/Cargo.toml
+++ b/bevy-butler/Cargo.toml
@@ -15,6 +15,7 @@ bevy-butler-proc-macro = { path = "../bevy-butler-proc-macro", version = "0.6.1"
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_log = { workspace = true }
+bevy_state = { workspace = true }
 inventory = { version = "0.3.17", optional = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]

--- a/bevy-butler/src/__internal/mod.rs
+++ b/bevy-butler/src/__internal/mod.rs
@@ -6,6 +6,7 @@ pub use linkme;
 pub use bevy_app;
 pub use bevy_ecs;
 pub use bevy_log;
+pub use bevy_state;
 
 mod plugin;
 pub use plugin::*;

--- a/bevy-butler/src/lib.rs
+++ b/bevy-butler/src/lib.rs
@@ -483,6 +483,67 @@ pub use bevy_butler_proc_macro::add_plugin;
 /// to [`Default::default()`] or the plugin itself if the plugin is a zero-size struct.
 pub use bevy_butler_proc_macro::add_plugin_group;
 
+/// Adds the annotated state to a `#[butler_plugin]`
+/// 
+/// # Usage
+/// ## On an enum
+/// ```rust
+/// # use bevy::prelude::*;
+/// # use bevy_butler::*;
+/// # #[butler_plugin]
+/// # struct GamePlugin;
+/// #[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
+/// #[insert_state(plugin = GamePlugin)]
+/// enum GameState {
+///     #[default]
+///     Loading,
+///     InGame
+/// }
+/// ```
+/// 
+/// ## On a use statement
+/// ```rust
+/// # use bevy_butler::*;
+/// # #[butler_plugin]
+/// # struct GamePlugin;
+/// # mod my_mod {
+/// #   use bevy::prelude::*;
+/// #   use bevy_butler::*;
+/// #   #[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
+/// #   pub enum GameState {
+/// #       #[default]
+/// #       Loading,
+/// #       InGame
+/// #   }
+/// # }
+/// #[insert_state(plugin = GamePlugin)]
+/// use my_mod::GameState;
+/// ```
+/// 
+/// # Arguments
+/// 
+/// ## `plugin` (Required)
+/// A [`Plugin`](bevy_app::prelude::Plugin) annotated with [`#[butler_plugin]`](butler_plugin) to register this state to.
+/// 
+/// ## `init`
+/// By default, `#[insert_state]` will use [`init_state`](bevy_state::app::AppExtStates::init_state) to add the given state.
+/// Setting the `init` argument will pass the given expression to [`insert_state`](bevy_state::app::AppExtStates::insert_state).
+/// ```rust
+/// # use bevy_butler::*;
+/// # use bevy::prelude::*;
+/// # #[butler_plugin]
+/// # struct GamePlugin;
+/// #[derive(States, Debug, Clone, PartialEq, Eq, Hash)]
+/// #[insert_state(plugin = GamePlugin, init = MyState::Bar)]
+/// enum MyState {
+///     Foo,
+///     Bar,
+///     Baz
+/// }
+/// ```
+/// 
+/// ## `generics`
+/// A list of generic arguments to register the state with. Used to register a generic state for multiple different types.
 pub use bevy_butler_proc_macro::insert_state;
 
 #[cfg(all(target_arch = "wasm32", not(feature = "wasm-experimental")))]

--- a/bevy-butler/src/lib.rs
+++ b/bevy-butler/src/lib.rs
@@ -483,6 +483,8 @@ pub use bevy_butler_proc_macro::add_plugin;
 /// to [`Default::default()`] or the plugin itself if the plugin is a zero-size struct.
 pub use bevy_butler_proc_macro::add_plugin_group;
 
+pub use bevy_butler_proc_macro::insert_state;
+
 #[cfg(all(target_arch = "wasm32", not(feature = "wasm-experimental")))]
 compile_error!(
     "WebAssembly support in bevy-butler is experimental and buggy.

--- a/bevy-butler/tests/add_event/main.rs
+++ b/bevy-butler/tests/add_event/main.rs
@@ -1,6 +1,4 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod event;
 mod event_enum;

--- a/bevy-butler/tests/add_observer/main.rs
+++ b/bevy-butler/tests/add_observer/main.rs
@@ -1,6 +1,4 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod observer;
 mod observer_use;

--- a/bevy-butler/tests/add_plugin/main.rs
+++ b/bevy-butler/tests/add_plugin/main.rs
@@ -1,6 +1,5 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
+
 
 mod add_default_plugin;
 mod add_plugin;

--- a/bevy-butler/tests/add_plugin_group/main.rs
+++ b/bevy-butler/tests/add_plugin_group/main.rs
@@ -1,6 +1,4 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod add_plugin_group;
 mod add_plugin_group_to_group;

--- a/bevy-butler/tests/add_system/main.rs
+++ b/bevy-butler/tests/add_system/main.rs
@@ -1,6 +1,4 @@
-pub mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod generic_pipe;
 mod generic_system;

--- a/bevy-butler/tests/add_system/system_expr_schedule.rs
+++ b/bevy-butler/tests/add_system/system_expr_schedule.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use bevy::{prelude::*, time::TimePlugin};
 use bevy_app::ScheduleRunnerPlugin;
 use bevy_butler::*;
-use bevy_state::{app::StatesPlugin, prelude::*};
+use bevy_state::app::StatesPlugin;
 
 use crate::common::log_plugin;
 

--- a/bevy-butler/tests/butler_plugin/main.rs
+++ b/bevy-butler/tests/butler_plugin/main.rs
@@ -1,6 +1,4 @@
-pub mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod butler_plugin;
 mod butler_plugin_enum;

--- a/bevy-butler/tests/butler_plugin_group/main.rs
+++ b/bevy-butler/tests/butler_plugin_group/main.rs
@@ -1,5 +1,3 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod butler_plugin_group;

--- a/bevy-butler/tests/common.rs
+++ b/bevy-butler/tests/common.rs
@@ -1,10 +1,12 @@
-use bevy_log::{Level, LogPlugin};
+pub mod common {
+    use bevy_log::{Level, LogPlugin};
 
-#[allow(dead_code)]
-pub fn log_plugin() -> LogPlugin {
-    LogPlugin {
-        filter: String::from("bevy_butler"),
-        level: Level::DEBUG,
-        ..Default::default()
+    #[allow(dead_code)]
+    pub fn log_plugin() -> LogPlugin {
+        LogPlugin {
+            filter: String::from("bevy_butler"),
+            level: Level::DEBUG,
+            ..Default::default()
+        }
     }
 }

--- a/bevy-butler/tests/insert_resource/main.rs
+++ b/bevy-butler/tests/insert_resource/main.rs
@@ -1,6 +1,4 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod generic_resource;
 mod non_send;

--- a/bevy-butler/tests/insert_state/insert_state.rs
+++ b/bevy-butler/tests/insert_state/insert_state.rs
@@ -1,0 +1,38 @@
+use bevy_butler::*;
+use bevy::prelude::*;
+use bevy_state::app::StatesPlugin;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[butler_plugin]
+struct GamePlugin;
+
+#[insert_state(plugin = GamePlugin)]
+#[derive(States, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+enum GameState {
+    #[default]
+    Loading,
+    InGame
+}
+
+#[add_system(plugin = GamePlugin, schedule = Startup)]
+fn enter_game(
+    mut next_state: ResMut<NextState<GameState>>
+) {
+    next_state.set(GameState::InGame);
+}
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test() {
+    let mut app = App::new();
+
+    app.add_plugins((StatesPlugin, GamePlugin));
+
+    let world = app.world_mut();
+    world.run_schedule(Startup);
+    world.run_schedule(StateTransition);
+
+    assert_eq!(
+        *world.get_resource::<State<GameState>>().expect("GameState was not inserted"),
+        GameState::InGame
+    );
+}

--- a/bevy-butler/tests/insert_state/main.rs
+++ b/bevy-butler/tests/insert_state/main.rs
@@ -1,0 +1,4 @@
+include!("../common.rs");
+
+mod insert_state;
+mod with_init;

--- a/bevy-butler/tests/insert_state/with_init.rs
+++ b/bevy-butler/tests/insert_state/with_init.rs
@@ -1,0 +1,37 @@
+use bevy_butler::*;
+use bevy::prelude::*;
+use bevy_state::app::StatesPlugin;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[butler_plugin]
+struct GamePlugin;
+
+#[insert_state(plugin = GamePlugin, init = GameState::Loading)]
+#[derive(States, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+enum GameState {
+    Loading,
+    InGame
+}
+
+#[add_system(plugin = GamePlugin, schedule = Startup)]
+fn enter_game(
+    mut next_state: ResMut<NextState<GameState>>
+) {
+    next_state.set(GameState::InGame);
+}
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test() {
+    let mut app = App::new();
+
+    app.add_plugins((StatesPlugin, GamePlugin));
+
+    let world = app.world_mut();
+    world.run_schedule(Startup);
+    world.run_schedule(StateTransition);
+
+    assert_eq!(
+        *world.get_resource::<State<GameState>>().expect("GameState was not inserted"),
+        GameState::InGame
+    );
+}

--- a/bevy-butler/tests/register_type/main.rs
+++ b/bevy-butler/tests/register_type/main.rs
@@ -1,6 +1,4 @@
-mod common {
-    include!("../common.rs");
-}
+include!("../common.rs");
 
 mod register_type;
 mod register_type_enum;


### PR DESCRIPTION
Adds the `insert_state` macro, which allows users to register a state to their plugin. Closes #27.

```rust
#[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
#[insert_state(plugin = GamePlugin)]
enum GameState {
    #[default]
    Loading,
    InGame
}
```

Also includes some general cleanup of the repo (i.e. moving common ident extraction code to utils)