### PR TITLE
Deprecate bevy_butler

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,21 @@
+# Migrating to [bevy_auto_plugin](https://github.com/StrikeForceZero/bevy_auto_plugin)
+
+This project has been deprecated due to a lack of time and motivation to maintain it. However, bevy_auto_plugin recently implemented much of the functionality that bevy-butler has, so I plan to send users to that plugin and contribute there in the future.
+
+Here is a quick list of which bevy-butler macros equate to which bevy_auto_plugin macros:
+- `#[add_event]` -> [`#[auto_event]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_event.html)
+- `#[add_observer]` -> [`#[auto_observer]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_observer.html)
+- `#[add_system]` -> [`#[auto_system]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_system.html)
+- `#[butler_plugin]` -> [`#[auto_plugin]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_plugin.html)
+- `#[insert_resource]` -> [`#[auto_init_resource]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_init_resource.html)/[`#[auto_insert_resource]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_insert_resource.html)
+- `#[insert_state]` -> [`#[auto_states]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_states.html)/[`#[auto_init_state]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_init_state.html)
+- `#[register_type]` -> [`#[auto_register_type]`](https://docs.rs/bevy_auto_plugin/0.5.0/bevy_auto_plugin/modes/global/prelude/attr.auto_register_type.html)
+
+Usage is fairly similar, but may need slight syntax changes.
+
+# Unsupported macros
+
+Some macros do not have direct replacements in bevy_auto_plugin.
+
+- `#[add_plugin]`
+- `#[butler_plugin_group]`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This library has been deprecated because I haven't had the time to keep up with it.
+> Another library named [bevy_auto_plugin](https://github.com/StrikeForceZero/bevy_auto_plugin) has implemented much of the same features, so I recommend you use that instead.
+
 # bevy-butler
 
 A set of procedural macros for making Bevy plugins and systems more self-documenting.


### PR DESCRIPTION
The library [bevy_auto_plugin](https://github.com/StrikeForceZero/bevy_auto_plugin) recently implemented much of the same features that bevy butler has. This, combined with my lack of time and motivation, has convinced me to deprecate bevy butler and redirect potential users to bevy_auto_plugin instead. If I want to add more features, I will contribute them there instead.

- [x] Add deprecation warning to the readme
- [x] Write a migration guide from bevy butler to bevy_auto_plugin